### PR TITLE
fix: prototype pollution in merge operator (CVE-2025-64718)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -120,6 +120,22 @@ function charFromCodepoint(c) {
   );
 }
 
+// set a property of a literal object, while protecting against prototype pollution,
+// see https://github.com/nodeca/js-yaml/issues/164 for more details
+function setProperty(object, key, value) {
+  // used for this specific key only because Object.defineProperty is slow
+  if (key === '__proto__') {
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: value
+    });
+  } else {
+    object[key] = value;
+  }
+}
+
 var simpleEscapeCheck = new Array(256); // integer, for fast access
 var simpleEscapeMap = new Array(256);
 for (var i = 0; i < 256; i++) {
@@ -298,7 +314,7 @@ function mergeMappings(state, destination, source, overridableKeys) {
     key = sourceKeys[index];
 
     if (!_hasOwnProperty.call(destination, key)) {
-      destination[key] = source[key];
+      setProperty(destination, key, source[key]);
       overridableKeys[key] = true;
     }
   }
@@ -358,17 +374,7 @@ function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valu
       throwError(state, 'duplicated mapping key');
     }
 
-    // used for this specific key only because Object.defineProperty is slow
-    if (keyNode === '__proto__') {
-      Object.defineProperty(_result, keyNode, {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: valueNode
-      });
-    } else {
-      _result[keyNode] = valueNode;
-    }
+    setProperty(_result, keyNode, valueNode);
     delete overridableKeys[keyNode];
   }
 

--- a/test/issues/0164.js
+++ b/test/issues/0164.js
@@ -6,9 +6,25 @@ const yaml = require('../../');
 
 
 it('should define __proto__ as a value (not invoke setter)', function () {
-  let object = yaml.load('{ __proto__: {foo: bar} }');
+  let object = yaml.load('{ __proto__: {polluted: bar} }');
 
   assert.strictEqual(({}).hasOwnProperty.call(yaml.load('{}'), '__proto__'), false);
   assert.strictEqual(({}).hasOwnProperty.call(object, '__proto__'), true);
-  assert(!object.foo);
+  assert(!object.polluted);
+});
+
+
+it('should merge __proto__ as a value with << operator', function () {
+  let object = yaml.load(`
+payload: &ref
+  polluted: bar
+
+foo:
+  <<:
+    __proto__: *ref
+  `);
+
+  assert.strictEqual(({}).hasOwnProperty.call(yaml.load('{}'), '__proto__'), false);
+  assert.strictEqual(({}).hasOwnProperty.call(object.foo, '__proto__'), true);
+  assert(!object.foo.polluted);
 });


### PR DESCRIPTION
## Summary

Cherry-pick of upstream fix for **CVE-2025-64718** (prototype pollution via YAML merge operator `<<`).

The `mergeMappings()` function was vulnerable to prototype pollution when parsing untrusted YAML containing `__proto__` keys with the merge operator.

## Changes

- Add `setProperty()` helper to safely handle `__proto__` keys
- Update `mergeMappings()` to use `setProperty()`
- Consolidate `storeMappingPair()` to use `setProperty()` (removes duplicate inline code)
- Add test case for merge operator vulnerability

## References

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-64718
- Upstream fix: https://github.com/nodeca/js-yaml/commit/383665ff4248ec2192d1274e934462bb30426879

## Test plan

- [x] Existing tests pass (`npm test`)
- [x] New test case verifies the fix
- [x] Manually verified prototype pollution no longer occurs